### PR TITLE
feat: add /api/health endpoint with DB check

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -821,6 +821,27 @@ app.delete('/api/events/:id', requireAuth, (req, res) => {
   res.json({ success: true });
 });
 
+// Health check
+app.get('/api/health', (req, res) => {
+  let dbStatus = 'ok';
+  try {
+    db.prepare('SELECT 1').get();
+  } catch {
+    dbStatus = 'error';
+  }
+
+  const status = dbStatus === 'ok' ? 'ok' : 'degraded';
+  res.status(status === 'ok' ? 200 : 503).json({
+    status,
+    service: 'sh-underground',
+    uptime: process.uptime(),
+    timestamp: new Date().toISOString(),
+    checks: {
+      database: dbStatus,
+    },
+  });
+});
+
 app.listen(PORT, () => {
   console.log(`SH Underground API running on port ${PORT}`);
 });


### PR DESCRIPTION
## Summary
Add a health check endpoint for production monitoring.

## Changes
- **server/index.js**: New `GET /api/health` endpoint with DB connectivity check

## Response Format
```json
{
  "status": "ok",
  "service": "sh-underground",
  "uptime": 3600,
  "timestamp": "2026-03-17T00:00:00Z",
  "checks": { "database": "ok" }
}
```

## Test Plan
- [x] Returns 200 with `status: ok` when DB is accessible
- [x] Returns 503 with `status: degraded` when DB is down
- [x] No auth required

Closes #3