### PR TITLE
✨ Add displayName field — use on map markers

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -77,6 +77,9 @@ if (!columnNames.includes('resetTokenExpires')) {
 if (!columnNames.includes('birthday')) {
   db.exec("ALTER TABLE users ADD COLUMN birthday TEXT DEFAULT ''");
 }
+if (!columnNames.includes('display_name')) {
+  db.exec("ALTER TABLE users ADD COLUMN display_name TEXT DEFAULT ''");
+}
 
 const RESET_TOKEN_EXPIRY_HOURS = 24;
 
@@ -186,6 +189,7 @@ const formatUser = (row) => ({
   markerColor: row.markerColor || 'red',
   profilePhoto: row.profilePhoto || null,
   birthday: row.birthday || '',
+  displayName: row.display_name || '',
 });
 
 const formatUserSession = (row) => ({
@@ -197,6 +201,7 @@ const formatUserSession = (row) => ({
   markerColor: row.markerColor || 'red',
   profilePhoto: row.profilePhoto || null,
   birthday: row.birthday || '',
+  displayName: row.display_name || '',
 });
 
 // Register
@@ -298,7 +303,7 @@ app.get('/api/user/:username', (req, res) => {
 // Update user profile
 app.put('/api/user/:username', (req, res) => {
   const { username } = req.params;
-  const { fullName, location, coordinates, markerColor, birthday } = req.body;
+  const { fullName, location, coordinates, markerColor, birthday, displayName } = req.body;
 
   const user = db.prepare('SELECT * FROM users WHERE username = ?').get(username);
 
@@ -316,12 +321,13 @@ app.put('/api/user/:username', (req, res) => {
     longitude: coordinates?.lng !== undefined ? coordinates.lng : user.longitude,
     markerColor: validMarkerColor || 'red',
     birthday: birthday !== undefined ? birthday : (user.birthday || ''),
+    displayName: displayName !== undefined ? displayName : (user.display_name || ''),
   };
 
   db.prepare(`
-    UPDATE users SET fullName = ?, location = ?, latitude = ?, longitude = ?, markerColor = ?, birthday = ?
+    UPDATE users SET fullName = ?, location = ?, latitude = ?, longitude = ?, markerColor = ?, birthday = ?, display_name = ?
     WHERE username = ?
-  `).run(updates.fullName, updates.location, updates.latitude, updates.longitude, updates.markerColor, updates.birthday, username);
+  `).run(updates.fullName, updates.location, updates.latitude, updates.longitude, updates.markerColor, updates.birthday, updates.displayName, username);
 
   const updated = db.prepare('SELECT * FROM users WHERE username = ?').get(username);
   res.json(formatUserSession(updated));

--- a/src/components/LocationMap.jsx
+++ b/src/components/LocationMap.jsx
@@ -18,7 +18,7 @@ const getPhotoUrl = (photoPath) => {
   return `/api${photoPath}`;
 };
 
-function LocationMap({ coordinates, locationName, username, fullName, markerColor = 'red', profilePhoto = null, otherUsers = [], onMapClick }) {
+function LocationMap({ coordinates, locationName, username, fullName, displayName, markerColor = 'red', profilePhoto = null, otherUsers = [], onMapClick }) {
   const [infoWindowOpen, setInfoWindowOpen] = useState(false);
   const [selectedUser, setSelectedUser] = useState(null);
 
@@ -83,7 +83,7 @@ function LocationMap({ coordinates, locationName, username, fullName, markerColo
         <MarkerF
           position={coordinates}
           onClick={handleMarkerClick}
-          label={username ? { text: username, color: '#000', fontWeight: 'bold', fontSize: '14px' } : undefined}
+          label={(displayName || username) ? { text: displayName || username, color: '#000', fontWeight: 'bold', fontSize: '14px' } : undefined}
           icon={{
             url: `http://maps.google.com/mapfiles/ms/icons/${markerColor}-dot.png`,
             scaledSize: new window.google.maps.Size(50, 50),
@@ -135,7 +135,7 @@ function LocationMap({ coordinates, locationName, username, fullName, markerColo
           key={person.id}
           position={person.coordinates}
           onClick={() => setSelectedUser(person)}
-          label={{ text: person.username, color: '#000', fontWeight: 'bold', fontSize: '12px' }}
+          label={{ text: person.displayName || person.username, color: '#000', fontWeight: 'bold', fontSize: '12px' }}
           icon={{
             url: `http://maps.google.com/mapfiles/ms/icons/${person.markerColor || 'blue'}-dot.png`,
             scaledSize: new window.google.maps.Size(40, 40),

--- a/src/pages/MapView.jsx
+++ b/src/pages/MapView.jsx
@@ -80,6 +80,7 @@ function MapView() {
               locationName={user.location}
               username={user.username}
               fullName={user.fullName}
+              displayName={user.displayName}
               markerColor={user.markerColor}
               profilePhoto={user.profilePhoto}
               otherUsers={otherUsers}

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -49,6 +49,7 @@ function Profile() {
   const { user, updateLocation, updateProfile, changePassword, refreshUser } = useAuth();
   const [fullName, setFullName] = useState(user?.fullName || '');
   const [birthday, setBirthday] = useState(user?.birthday || '');
+  const [displayName, setDisplayName] = useState(user?.displayName || '');
   const [markerColor, setMarkerColor] = useState(user?.markerColor || 'red');
   const [markerColors, setMarkerColors] = useState([]);
   const [locationInput, setLocationInput] = useState(user?.location || '');
@@ -154,7 +155,7 @@ function Profile() {
 
   const handleSaveProfile = async () => {
     try {
-      await updateProfile({ fullName, markerColor, birthday });
+      await updateProfile({ fullName, displayName, markerColor, birthday });
       setSuccess('Profile saved successfully!');
     } catch (err) {
       setError(err.message);
@@ -351,6 +352,14 @@ function Profile() {
             placeholder="Enter your full name"
             value={fullName}
             onChange={(e) => setFullName(e.target.value)}
+          />
+          <TextField
+            sx={{ flex: 1, minWidth: 200 }}
+            label="Display Name"
+            placeholder="Shown on map (leave blank to use username)"
+            value={displayName}
+            onChange={(e) => setDisplayName(e.target.value)}
+            inputProps={{ maxLength: 30 }}
           />
           <TextField
             sx={{ minWidth: 180 }}


### PR DESCRIPTION
## Summary
3 commits adding a display name field for map markers.

### Changes
- **Backend**: `display_name` column migration, exposed in user responses, saved via profile update endpoint
- **Profile page**: New 'Display Name' field (between Full Name and Birthday), max 30 chars, hint text explains it's for the map
- **Map markers**: Use `displayName` if set, fallback to `username`

## Behavior
- Leave blank → map shows username (existing behavior)
- Set a display name → map shows that instead of username

## Test Plan
- [ ] Set a display name on profile
- [ ] Map marker shows the display name
- [ ] Other users' markers also use their display name when set

Closes #14