### PR TITLE
Add admin-issued password reset links

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,6 +4,7 @@ import ProtectedRoute from './components/ProtectedRoute';
 import LandingPage from './pages/LandingPage';
 import Login from './pages/Login';
 import Register from './pages/Register';
+import ResetPassword from './pages/ResetPassword';
 import Profile from './pages/Profile';
 import MapView from './pages/MapView';
 import AdminDashboard from './pages/AdminDashboard';
@@ -15,6 +16,7 @@ function App() {
       <Route path="/" element={<LandingPage />} />
       <Route path="/login" element={<Login />} />
       <Route path="/register" element={<Register />} />
+      <Route path="/reset-password" element={<ResetPassword />} />
       <Route
         path="/app"
         element={

--- a/src/api.js
+++ b/src/api.js
@@ -76,6 +76,36 @@ export const api = {
     return res.json();
   },
 
+  async generateResetToken(username) {
+    const res = await fetch(`${API_BASE}/admin/user/${username}/reset-token`, {
+      method: 'POST',
+      headers: getAuthHeaders(),
+    });
+    if (!res.ok) {
+      const data = await res.json();
+      throw new Error(data.error || 'Failed to generate reset token');
+    }
+    return res.json();
+  },
+
+  async verifyResetToken(token) {
+    const res = await fetch(`${API_BASE}/verify-reset-token/${token}`);
+    return res.json();
+  },
+
+  async resetPassword(token, newPassword) {
+    const res = await fetch(`${API_BASE}/reset-password`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ token, newPassword }),
+    });
+    if (!res.ok) {
+      const data = await res.json();
+      throw new Error(data.error || 'Failed to reset password');
+    }
+    return res.json();
+  },
+
   async getAllUsers() {
     const res = await fetch(`${API_BASE}/users`);
     if (!res.ok) {

--- a/src/pages/AdminDashboard.jsx
+++ b/src/pages/AdminDashboard.jsx
@@ -30,6 +30,8 @@ import DownloadIcon from '@mui/icons-material/Download';
 import UploadIcon from '@mui/icons-material/Upload';
 import BlockIcon from '@mui/icons-material/Block';
 import CalendarMonthIcon from '@mui/icons-material/CalendarMonth';
+import LockResetIcon from '@mui/icons-material/LockReset';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import { useAuth } from '../contexts/AuthContext';
 import { Navigate } from 'react-router-dom';
 import { api } from '../api';
@@ -52,6 +54,9 @@ function AdminDashboard() {
   const [calendarImportDialogOpen, setCalendarImportDialogOpen] = useState(false);
   const [calendarImportData, setCalendarImportData] = useState(null);
   const [calendarImportMode, setCalendarImportMode] = useState('merge');
+  const [resetLinkDialogOpen, setResetLinkDialogOpen] = useState(false);
+  const [resetLinkData, setResetLinkData] = useState(null);
+  const [resetLinkCopied, setResetLinkCopied] = useState(false);
   const fileInputRef = useRef(null);
   const calendarFileInputRef = useRef(null);
 
@@ -110,6 +115,30 @@ function AdminDashboard() {
     });
     setEditDialogOpen(true);
     setError('');
+  };
+
+  const handleGenerateResetLink = async (userToReset) => {
+    setError('');
+    try {
+      const data = await api.generateResetToken(userToReset.username);
+      const fullUrl = `${window.location.origin}/reset-password?token=${data.resetToken}`;
+      setResetLinkData({ ...data, fullUrl });
+      setResetLinkCopied(false);
+      setResetLinkDialogOpen(true);
+    } catch (err) {
+      setError(err.message);
+    }
+  };
+
+  const handleCopyResetLink = async () => {
+    if (!resetLinkData) return;
+    try {
+      await navigator.clipboard.writeText(resetLinkData.fullUrl);
+      setResetLinkCopied(true);
+      setTimeout(() => setResetLinkCopied(false), 2000);
+    } catch {
+      setError('Failed to copy to clipboard');
+    }
   };
 
   const handleDeleteClick = (userToDelete) => {
@@ -336,14 +365,24 @@ function AdminDashboard() {
                       color="primary"
                       onClick={() => handleEditClick(u)}
                       size="small"
+                      title="Edit user"
                     >
                       <EditIcon />
+                    </IconButton>
+                    <IconButton
+                      color="warning"
+                      onClick={() => handleGenerateResetLink(u)}
+                      size="small"
+                      title="Generate password reset link"
+                    >
+                      <LockResetIcon />
                     </IconButton>
                     <IconButton
                       color="error"
                       onClick={() => handleDeleteClick(u)}
                       size="small"
                       disabled={u.username === user.username}
+                      title="Delete user"
                     >
                       <DeleteIcon />
                     </IconButton>
@@ -401,6 +440,42 @@ function AdminDashboard() {
           <Button onClick={() => setDeleteDialogOpen(false)}>Cancel</Button>
           <Button onClick={handleDeleteConfirm} color="error" variant="contained">
             Delete
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Reset Link Dialog */}
+      <Dialog open={resetLinkDialogOpen} onClose={() => setResetLinkDialogOpen(false)} maxWidth="sm" fullWidth>
+        <DialogTitle>Password Reset Link</DialogTitle>
+        <DialogContent>
+          <Typography variant="body2" sx={{ mb: 2 }}>
+            Send this link to <strong>{resetLinkData?.username}</strong>. It expires in 24 hours and can only be used once.
+          </Typography>
+          <TextField
+            fullWidth
+            multiline
+            value={resetLinkData?.fullUrl || ''}
+            InputProps={{
+              readOnly: true,
+              sx: { fontFamily: 'monospace', fontSize: '0.85rem' },
+            }}
+            onClick={(e) => e.target.select()}
+          />
+          {resetLinkData?.expiresAt && (
+            <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 1 }}>
+              Expires: {new Date(resetLinkData.expiresAt).toLocaleString()}
+            </Typography>
+          )}
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setResetLinkDialogOpen(false)}>Close</Button>
+          <Button
+            onClick={handleCopyResetLink}
+            variant="contained"
+            startIcon={<ContentCopyIcon />}
+            color={resetLinkCopied ? 'success' : 'primary'}
+          >
+            {resetLinkCopied ? 'Copied!' : 'Copy Link'}
           </Button>
         </DialogActions>
       </Dialog>

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -116,6 +116,9 @@ function Login() {
               <Typography variant="body2" color="text.secondary">
                 Need an account? Ask a member for an invite link.
               </Typography>
+              <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+                Forgot your password? Contact an admin for a reset link.
+              </Typography>
             </Box>
           </Box>
         </Paper>

--- a/src/pages/ResetPassword.jsx
+++ b/src/pages/ResetPassword.jsx
@@ -1,0 +1,185 @@
+import { useState, useEffect } from 'react';
+import { useSearchParams, useNavigate, Link as RouterLink } from 'react-router-dom';
+import {
+  Container,
+  Box,
+  Typography,
+  TextField,
+  Button,
+  Alert,
+  Paper,
+  CircularProgress,
+  Link,
+} from '@mui/material';
+import { api } from '../api';
+
+function ResetPassword() {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const token = searchParams.get('token');
+
+  const [verifying, setVerifying] = useState(true);
+  const [tokenValid, setTokenValid] = useState(false);
+  const [tokenError, setTokenError] = useState('');
+  const [username, setUsername] = useState('');
+
+  const [newPassword, setNewPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (!token) {
+      setTokenError('No reset token provided');
+      setVerifying(false);
+      return;
+    }
+    api.verifyResetToken(token).then((res) => {
+      if (res.valid) {
+        setTokenValid(true);
+        setUsername(res.username || '');
+      } else {
+        setTokenError(res.error || 'Invalid reset token');
+      }
+      setVerifying(false);
+    }).catch(() => {
+      setTokenError('Failed to verify token');
+      setVerifying(false);
+    });
+  }, [token]);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError('');
+
+    if (newPassword.length < 6) {
+      setError('Password must be at least 6 characters');
+      return;
+    }
+    if (newPassword !== confirmPassword) {
+      setError('Passwords do not match');
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      await api.resetPassword(token, newPassword);
+      setSuccess(true);
+      setTimeout(() => navigate('/login'), 2500);
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Container maxWidth="sm">
+      <Box
+        sx={{
+          minHeight: '100vh',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'center',
+        }}
+      >
+        <Paper elevation={3} sx={{ p: 4 }}>
+          <Box
+            sx={{
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              mb: 3,
+            }}
+          >
+            <Box
+              component="img"
+              src="/logo-2.jpg"
+              alt="SH Underground"
+              sx={{ width: 100, height: 100, mb: 2 }}
+            />
+            <Typography component="h1" variant="h4" sx={{ color: 'primary.main' }}>
+              Reset Password
+            </Typography>
+          </Box>
+
+          {verifying && (
+            <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+              <CircularProgress />
+            </Box>
+          )}
+
+          {!verifying && tokenError && (
+            <>
+              <Alert severity="error" sx={{ mb: 2 }}>
+                {tokenError}
+              </Alert>
+              <Typography variant="body2" color="text.secondary" sx={{ textAlign: 'center' }}>
+                Reset links expire after 24 hours. Contact an admin for a new one.{' '}
+                <Link component={RouterLink} to="/login">Back to login</Link>
+              </Typography>
+            </>
+          )}
+
+          {!verifying && tokenValid && success && (
+            <Alert severity="success">
+              Password reset successfully. Redirecting to login...
+            </Alert>
+          )}
+
+          {!verifying && tokenValid && !success && (
+            <Box component="form" onSubmit={handleSubmit}>
+              {username && (
+                <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+                  Resetting password for <strong>{username}</strong>
+                </Typography>
+              )}
+
+              {error && (
+                <Alert severity="error" sx={{ mb: 2 }}>
+                  {error}
+                </Alert>
+              )}
+
+              <TextField
+                margin="normal"
+                required
+                fullWidth
+                name="newPassword"
+                label="New Password"
+                type="password"
+                autoComplete="new-password"
+                autoFocus
+                value={newPassword}
+                onChange={(e) => setNewPassword(e.target.value)}
+              />
+              <TextField
+                margin="normal"
+                required
+                fullWidth
+                name="confirmPassword"
+                label="Confirm New Password"
+                type="password"
+                autoComplete="new-password"
+                value={confirmPassword}
+                onChange={(e) => setConfirmPassword(e.target.value)}
+              />
+              <Button
+                type="submit"
+                fullWidth
+                variant="contained"
+                sx={{ mt: 3, mb: 2 }}
+                disabled={submitting}
+              >
+                {submitting ? 'Resetting...' : 'Reset Password'}
+              </Button>
+            </Box>
+          )}
+        </Paper>
+      </Box>
+    </Container>
+  );
+}
+
+export default ResetPassword;


### PR DESCRIPTION
## Summary

- Adds an admin-mediated password reset flow that reuses existing backend endpoints (`/api/admin/user/:username/reset-token`, `/api/verify-reset-token/:token`, `/api/reset-password`) — no server changes needed.
- Admins can now generate a one-time reset URL for any user from the dashboard and copy it to clipboard for out-of-band delivery (Signal, Discord, etc.).
- Tokens expire after 24 hours and are invalidated on use.

## Changes

- **src/api.js**: add `generateResetToken`, `verifyResetToken`, and `resetPassword` client wrappers.
- **src/pages/ResetPassword.jsx**: new public page at `/reset-password?token=...` — verifies the token on mount, accepts new + confirm password (min 6 chars), redirects to `/login` on success, surfaces clear errors for invalid/expired tokens.
- **src/App.jsx**: register the public `/reset-password` route.
- **src/pages/Login.jsx**: add "Forgot your password? Contact an admin for a reset link." hint.
- **src/pages/AdminDashboard.jsx**: add a `LockReset` icon button on each user row that generates a reset link and opens a dialog with copy-to-clipboard support and the expiration time.

## Test Plan

- [x] Log in as admin (`guntharp`), visit `/app/admin`, click the orange lock icon on a non-admin user — dialog should display a `/reset-password?token=...` URL.
- [x] Click "Copy Link" — button turns green and reads "Copied!" briefly.
- [x] Open the copied URL in an incognito window — page loads, shows the username it belongs to.
- [x] Submit a new password (min 6 chars, matching confirm) — see success and auto-redirect to `/login`.
- [x] Log in as that user with the new password — succeeds.
- [x] Re-use the same token — should fail with "Invalid or expired reset token".
- [x] Visit `/reset-password` with no token query param — shows error and a back-to-login link.
- [x] Visit `/reset-password?token=junk` — shows invalid-token error.
- [x] Confirm Login page displays the new "contact an admin" hint.