### PR TITLE
Enforce email-format usernames with legacy migration

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -7,6 +7,7 @@ const multer = require('multer');
 const Database = require('better-sqlite3');
 
 const SALT_ROUNDS = 10;
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 const app = express();
 const PORT = 3002;
@@ -206,10 +207,15 @@ const formatUserSession = (row) => ({
 
 // Register
 app.post('/api/register', async (req, res) => {
-  const { username, password, inviteToken } = req.body;
+  const { username: rawUsername, password, inviteToken } = req.body;
 
-  if (!username || !password) {
+  if (!rawUsername || !password) {
     return res.status(400).json({ error: 'Username and password required' });
+  }
+
+  const username = String(rawUsername).trim().toLowerCase();
+  if (!EMAIL_REGEX.test(username)) {
+    return res.status(400).json({ error: 'Username must be a valid email address' });
   }
 
   if (!inviteToken) {
@@ -228,7 +234,7 @@ app.post('/api/register', async (req, res) => {
     return res.status(400).json({ error: 'Invite token has been revoked' });
   }
 
-  const existing = db.prepare('SELECT username FROM users WHERE username = ?').get(username);
+  const existing = db.prepare('SELECT username FROM users WHERE username = ? COLLATE NOCASE').get(username);
   if (existing) {
     return res.status(400).json({ error: 'Username already exists' });
   }
@@ -271,9 +277,14 @@ app.post('/api/register', async (req, res) => {
 
 // Login
 app.post('/api/login', async (req, res) => {
-  const { username, password } = req.body;
+  const { username: rawUsername, password } = req.body;
 
-  const user = db.prepare('SELECT * FROM users WHERE username = ?').get(username);
+  if (!rawUsername || !password) {
+    return res.status(401).json({ error: 'Invalid username or password' });
+  }
+
+  const lookup = String(rawUsername).trim();
+  const user = db.prepare('SELECT * FROM users WHERE username = ? COLLATE NOCASE').get(lookup);
 
   if (!user) {
     return res.status(401).json({ error: 'Invalid username or password' });
@@ -284,7 +295,88 @@ app.post('/api/login', async (req, res) => {
     return res.status(401).json({ error: 'Invalid username or password' });
   }
 
-  res.json(formatUserSession(user));
+  res.json({
+    ...formatUserSession(user),
+    needsMigration: !EMAIL_REGEX.test(user.username),
+  });
+});
+
+// Migrate legacy username to email
+app.post('/api/migrate-username', async (req, res) => {
+  const { currentUsername, password, newUsername: rawNewUsername } = req.body;
+
+  if (!currentUsername || !password || !rawNewUsername) {
+    return res.status(400).json({ error: 'Current username, password, and new email required' });
+  }
+
+  const newUsername = String(rawNewUsername).trim().toLowerCase();
+  if (!EMAIL_REGEX.test(newUsername)) {
+    return res.status(400).json({ error: 'New username must be a valid email address' });
+  }
+
+  const user = db.prepare('SELECT * FROM users WHERE username = ? COLLATE NOCASE').get(currentUsername);
+  if (!user) {
+    return res.status(401).json({ error: 'Invalid username or password' });
+  }
+
+  const passwordMatch = await bcrypt.compare(password, user.password);
+  if (!passwordMatch) {
+    return res.status(401).json({ error: 'Invalid username or password' });
+  }
+
+  // If they're already an email, no-op
+  if (EMAIL_REGEX.test(user.username) && user.username === newUsername) {
+    return res.json(formatUserSession(user));
+  }
+
+  const collision = db.prepare('SELECT username FROM users WHERE username = ? COLLATE NOCASE').get(newUsername);
+  if (collision && collision.username.toLowerCase() !== user.username.toLowerCase()) {
+    return res.status(400).json({ error: 'That email is already in use' });
+  }
+
+  // Compute new photo URL/path if user has one
+  let newPhotoUrl = user.profilePhoto;
+  let oldPhotoPath = null;
+  let newPhotoPath = null;
+  if (user.profilePhoto) {
+    const oldFilename = path.basename(user.profilePhoto);
+    const prefix = `${user.username}-`;
+    if (oldFilename.startsWith(prefix)) {
+      const newFilename = `${newUsername}-${oldFilename.slice(prefix.length)}`;
+      oldPhotoPath = path.join(uploadsDir, oldFilename);
+      newPhotoPath = path.join(uploadsDir, newFilename);
+      newPhotoUrl = user.profilePhoto.replace(oldFilename, newFilename);
+    }
+  }
+
+  const migrate = db.transaction(() => {
+    db.prepare('UPDATE users SET username = ?, profilePhoto = ? WHERE username = ?')
+      .run(newUsername, newPhotoUrl, user.username);
+    db.prepare('UPDATE invite_tokens SET created_by = ? WHERE created_by = ?')
+      .run(newUsername, user.username);
+    db.prepare('UPDATE invite_tokens SET used_by = ? WHERE used_by = ?')
+      .run(newUsername, user.username);
+    db.prepare('UPDATE calendar_events SET created_by = ? WHERE created_by = ?')
+      .run(newUsername, user.username);
+  });
+
+  try {
+    migrate();
+  } catch (err) {
+    return res.status(500).json({ error: err.message });
+  }
+
+  // Rename photo file after DB commit (best-effort; URL already updated)
+  if (oldPhotoPath && newPhotoPath && fs.existsSync(oldPhotoPath)) {
+    try {
+      fs.renameSync(oldPhotoPath, newPhotoPath);
+    } catch {
+      // file rename failed — leave URL pointing at new name; admin can fix
+    }
+  }
+
+  const updated = db.prepare('SELECT * FROM users WHERE username = ?').get(newUsername);
+  res.json(formatUserSession(updated));
 });
 
 // Get current user (refresh session data)

--- a/src/api.js
+++ b/src/api.js
@@ -41,6 +41,19 @@ export const api = {
     return res.json();
   },
 
+  async migrateUsername(currentUsername, password, newUsername) {
+    const res = await fetch(`${API_BASE}/migrate-username`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ currentUsername, password, newUsername }),
+    });
+    if (!res.ok) {
+      const data = await res.json();
+      throw new Error(data.error || 'Migration failed');
+    }
+    return res.json();
+  },
+
   async getUser(username) {
     const res = await fetch(`${API_BASE}/user/${username}`);
     if (!res.ok) {

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -4,7 +4,6 @@ import { api } from '../api';
 const AuthContext = createContext(null);
 
 const CURRENT_USER_KEY = 'location_app_current_user';
-const ADMIN_USERS = ['guntharp'];
 
 export function AuthProvider({ children }) {
   const [user, setUser] = useState(null);
@@ -18,12 +17,10 @@ export function AuthProvider({ children }) {
         try {
           // Refresh user data from server
           const freshUser = await api.getUser(parsed.username);
-          freshUser.isAdmin = ADMIN_USERS.includes(freshUser.username);
           setUser(freshUser);
           localStorage.setItem(CURRENT_USER_KEY, JSON.stringify(freshUser));
         } catch {
           // If server fails, use cached data
-          parsed.isAdmin = ADMIN_USERS.includes(parsed.username);
           setUser(parsed);
         }
       }
@@ -32,20 +29,31 @@ export function AuthProvider({ children }) {
     initAuth();
   }, []);
 
+  const persistSession = (session) => {
+    setUser(session);
+    localStorage.setItem(CURRENT_USER_KEY, JSON.stringify(session));
+  };
+
   const register = async (username, password, inviteToken) => {
     const userSession = await api.register(username, password, inviteToken);
-    userSession.isAdmin = ADMIN_USERS.includes(username);
-    setUser(userSession);
-    localStorage.setItem(CURRENT_USER_KEY, JSON.stringify(userSession));
+    persistSession(userSession);
     return userSession;
   };
 
   const login = async (username, password) => {
-    const userSession = await api.login(username, password);
-    userSession.isAdmin = ADMIN_USERS.includes(username);
-    setUser(userSession);
-    localStorage.setItem(CURRENT_USER_KEY, JSON.stringify(userSession));
-    return userSession;
+    const response = await api.login(username, password);
+    // If migration is required, do NOT establish a session — caller must complete migration first
+    if (response.needsMigration) {
+      return response;
+    }
+    persistSession(response);
+    return response;
+  };
+
+  const completeMigration = async (currentUsername, password, newUsername) => {
+    const response = await api.migrateUsername(currentUsername, password, newUsername);
+    persistSession(response);
+    return response;
   };
 
   const logout = () => {
@@ -55,16 +63,12 @@ export function AuthProvider({ children }) {
 
   const updateLocation = async (location, coordinates) => {
     const updatedUser = await api.updateUser(user.username, { location, coordinates });
-    updatedUser.isAdmin = user.isAdmin;
-    setUser(updatedUser);
-    localStorage.setItem(CURRENT_USER_KEY, JSON.stringify(updatedUser));
+    persistSession(updatedUser);
   };
 
   const updateProfile = async (profileData) => {
     const updatedUser = await api.updateUser(user.username, profileData);
-    updatedUser.isAdmin = user.isAdmin;
-    setUser(updatedUser);
-    localStorage.setItem(CURRENT_USER_KEY, JSON.stringify(updatedUser));
+    persistSession(updatedUser);
   };
 
   const changePassword = async (currentPassword, newPassword) => {
@@ -74,9 +78,7 @@ export function AuthProvider({ children }) {
   const refreshUser = async () => {
     if (!user?.username) return;
     const freshUser = await api.getUser(user.username);
-    freshUser.isAdmin = user.isAdmin;
-    setUser(freshUser);
-    localStorage.setItem(CURRENT_USER_KEY, JSON.stringify(freshUser));
+    persistSession(freshUser);
   };
 
   const value = {
@@ -84,6 +86,7 @@ export function AuthProvider({ children }) {
     loading,
     register,
     login,
+    completeMigration,
     logout,
     updateLocation,
     updateProfile,

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -11,12 +11,16 @@ import {
 } from '@mui/material';
 import { useAuth } from '../contexts/AuthContext';
 
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
 function Login() {
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
-  const { login } = useAuth();
+  const [migrationRequired, setMigrationRequired] = useState(false);
+  const [newEmail, setNewEmail] = useState('');
+  const { login, completeMigration } = useAuth();
   const navigate = useNavigate();
 
   const handleSubmit = async (e) => {
@@ -30,7 +34,32 @@ function Login() {
 
     setLoading(true);
     try {
-      await login(username, password);
+      const result = await login(username, password);
+      if (result.needsMigration) {
+        setMigrationRequired(true);
+      } else {
+        navigate('/app/profile');
+      }
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleMigrate = async (e) => {
+    e.preventDefault();
+    setError('');
+
+    const normalized = newEmail.trim().toLowerCase();
+    if (!EMAIL_REGEX.test(normalized)) {
+      setError('Please enter a valid email address');
+      return;
+    }
+
+    setLoading(true);
+    try {
+      await completeMigration(username, password, normalized);
       navigate('/app/profile');
     } catch (err) {
       setError(err.message);
@@ -68,7 +97,7 @@ function Login() {
               SH Underground
             </Typography>
             <Typography variant="body2" color="text.secondary">
-              Sign in to your account
+              {migrationRequired ? 'Set your email to continue' : 'Sign in to your account'}
             </Typography>
           </Box>
 
@@ -78,49 +107,79 @@ function Login() {
             </Alert>
           )}
 
-          <Box component="form" onSubmit={handleSubmit}>
-            <TextField
-              margin="normal"
-              required
-              fullWidth
-              id="username"
-              label="Username"
-              name="username"
-              autoComplete="username"
-              autoFocus
-              value={username}
-              onChange={(e) => setUsername(e.target.value)}
-            />
-            <TextField
-              margin="normal"
-              required
-              fullWidth
-              name="password"
-              label="Password"
-              type="password"
-              id="password"
-              autoComplete="current-password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-            />
-            <Button
-              type="submit"
-              fullWidth
-              variant="contained"
-              sx={{ mt: 3, mb: 2 }}
-              disabled={loading}
-            >
-              {loading ? 'Signing in...' : 'Sign In'}
-            </Button>
-            <Box sx={{ textAlign: 'center' }}>
-              <Typography variant="body2" color="text.secondary">
-                Need an account? Ask a member for an invite link.
-              </Typography>
-              <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
-                Forgot your password? Contact an admin for a reset link.
-              </Typography>
+          {migrationRequired ? (
+            <Box component="form" onSubmit={handleMigrate}>
+              <Alert severity="info" sx={{ mb: 2 }}>
+                Usernames are now email addresses. Enter your email to update your account — this will be your new login.
+              </Alert>
+              <TextField
+                margin="normal"
+                required
+                fullWidth
+                id="newEmail"
+                label="Email"
+                name="newEmail"
+                type="email"
+                autoComplete="email"
+                autoFocus
+                value={newEmail}
+                onChange={(e) => setNewEmail(e.target.value)}
+              />
+              <Button
+                type="submit"
+                fullWidth
+                variant="contained"
+                sx={{ mt: 3, mb: 2 }}
+                disabled={loading}
+              >
+                {loading ? 'Updating...' : 'Update and continue'}
+              </Button>
             </Box>
-          </Box>
+          ) : (
+            <Box component="form" onSubmit={handleSubmit}>
+              <TextField
+                margin="normal"
+                required
+                fullWidth
+                id="username"
+                label="Username or Email"
+                name="username"
+                autoComplete="username"
+                autoFocus
+                value={username}
+                onChange={(e) => setUsername(e.target.value)}
+              />
+              <TextField
+                margin="normal"
+                required
+                fullWidth
+                name="password"
+                label="Password"
+                type="password"
+                id="password"
+                autoComplete="current-password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+              />
+              <Button
+                type="submit"
+                fullWidth
+                variant="contained"
+                sx={{ mt: 3, mb: 2 }}
+                disabled={loading}
+              >
+                {loading ? 'Signing in...' : 'Sign In'}
+              </Button>
+              <Box sx={{ textAlign: 'center' }}>
+                <Typography variant="body2" color="text.secondary">
+                  Need an account? Ask a member for an invite link.
+                </Typography>
+                <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+                  Forgot your password? Contact an admin for a reset link.
+                </Typography>
+              </Box>
+            </Box>
+          )}
         </Paper>
       </Box>
     </Container>

--- a/src/pages/Register.jsx
+++ b/src/pages/Register.jsx
@@ -12,6 +12,8 @@ import {
 } from '@mui/material';
 import { useAuth } from '../contexts/AuthContext';
 
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
 function Register() {
   const [searchParams] = useSearchParams();
   const inviteToken = searchParams.get('invite');
@@ -27,13 +29,15 @@ function Register() {
     e.preventDefault();
     setError('');
 
-    if (!username.trim() || !password.trim()) {
+    const normalizedUsername = username.trim().toLowerCase();
+
+    if (!normalizedUsername || !password.trim()) {
       setError('Please fill in all fields');
       return;
     }
 
-    if (username.length < 3) {
-      setError('Username must be at least 3 characters');
+    if (!EMAIL_REGEX.test(normalizedUsername)) {
+      setError('Username must be a valid email address');
       return;
     }
 
@@ -49,7 +53,7 @@ function Register() {
 
     setLoading(true);
     try {
-      await register(username, password, inviteToken);
+      await register(normalizedUsername, password, inviteToken);
       navigate('/app/profile');
     } catch (err) {
       setError(err.message);
@@ -124,9 +128,10 @@ function Register() {
                   required
                   fullWidth
                   id="username"
-                  label="Username"
+                  label="Email"
                   name="username"
-                  autoComplete="username"
+                  type="email"
+                  autoComplete="email"
                   autoFocus
                   value={username}
                   onChange={(e) => setUsername(e.target.value)}


### PR DESCRIPTION
## Summary

- New registrations now require an email-formatted username (validated client + server, lowercased on save)
- Existing non-email users are forced through an inline migration on next login — username PK is renamed and all FK references follow
- Removes the hardcoded `ADMIN_USERS = ['guntharp']` shim; server `isAdmin` column is the sole source of truth
- Login lookups are now case-insensitive (`COLLATE NOCASE`) so legacy mixed-case usernames keep working

## Changes

- **server/index.js**: add `EMAIL_REGEX`; validate + lowercase on `/api/register`; case-insensitive login that returns `needsMigration` when the stored username isn't email-shaped; new `/api/migrate-username` endpoint that re-verifies password, validates the new email, then atomically renames `users.username` and rewrites `invite_tokens.created_by`, `invite_tokens.used_by`, `calendar_events.created_by`. Renames the profile-photo file on disk and updates the stored URL.
- **src/api.js**: add `migrateUsername` client method.
- **src/contexts/AuthContext.jsx**: drop `ADMIN_USERS`; `login` no longer establishes a session when `needsMigration` is true; new `completeMigration` finishes the flow.
- **src/pages/Login.jsx**: after a successful credential check, if `needsMigration` is true, swaps inline to a "Set your email" form; submit calls `completeMigration` and navigates on success. Field label updated to "Username or Email" for the transition.
- **src/pages/Register.jsx**: replace the 3-char username minimum with an email regex, lowercase before submit, set `type="email"` and re-label as "Email".

## Test Plan

- [x] Register with a non-email username → rejected with "Username must be a valid email address"
- [x] Register with `Foo@Example.com` → row stored as `foo@example.com`
- [x] Register with an email that collides (any case) with an existing user → rejected
- [x] Login as a legacy non-email user → inline "Set your email" form appears, no session established yet
- [x] Submit migration with a bad email → rejected, password preserved
- [x] Submit migration with a colliding email (any case) → rejected
- [x] Submit migration successfully → navigates to `/app/profile`; verify in DB that `users.username`, `invite_tokens.created_by`, `invite_tokens.used_by`, and `calendar_events.created_by` were all rewritten
- [x] If user had a profile photo, verify the file on disk was renamed and the URL updated
- [x] Login with the new email after migration → no migration prompt, session established
- [x] Admin user (`guntharp` → `fusion94@gmail.com`) retains admin access after migration