### PR TITLE
feat: audit event logging with admin viewer

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -12,6 +12,11 @@ const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const app = express();
 const PORT = 3002;
 
+// Trust the loopback proxy (Nginx in prod, Vite dev proxy locally) so req.ip
+// reflects the real client IP forwarded via X-Forwarded-For. 'loopback' rejects
+// header spoofing from non-localhost upstreams.
+app.set('trust proxy', 'loopback');
+
 // Ensure data directory exists
 const dataDir = path.join(__dirname, 'data');
 const uploadsDir = path.join(__dirname, 'uploads');
@@ -148,6 +153,24 @@ if (!calColNames.includes('end_date')) {
   db.exec("ALTER TABLE calendar_events ADD COLUMN end_date TEXT DEFAULT ''");
 }
 
+// Audit log
+db.exec(`
+  CREATE TABLE IF NOT EXISTS audit_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    timestamp INTEGER NOT NULL,
+    event_type TEXT NOT NULL,
+    actor TEXT,
+    target TEXT,
+    details TEXT,
+    ip TEXT,
+    user_agent TEXT
+  )
+`);
+db.exec('CREATE INDEX IF NOT EXISTS idx_audit_timestamp ON audit_events(timestamp DESC)');
+db.exec('CREATE INDEX IF NOT EXISTS idx_audit_event_type ON audit_events(event_type)');
+db.exec('CREATE INDEX IF NOT EXISTS idx_audit_actor ON audit_events(actor)');
+db.exec('CREATE INDEX IF NOT EXISTS idx_audit_target ON audit_events(target)');
+
 app.use(cors());
 app.use(express.json());
 app.use('/uploads', express.static(uploadsDir));
@@ -219,37 +242,82 @@ const formatUserSession = (row) => ({
   displayName: row.display_name || '',
 });
 
+// Audit logging — must never throw out of the parent request
+const MAX_AUDIT_DETAILS_BYTES = 4096;
+const insertAuditStmt = db.prepare(`
+  INSERT INTO audit_events (timestamp, event_type, actor, target, details, ip, user_agent)
+  VALUES (?, ?, ?, ?, ?, ?, ?)
+`);
+
+function logEvent(req, { type, actor, target, details } = {}) {
+  try {
+    if (!type) return;
+    const resolvedActor = actor !== undefined ? actor : (req?.headers?.['x-username'] || null);
+    let detailsJson = null;
+    if (details !== undefined && details !== null) {
+      let serialized;
+      try {
+        serialized = JSON.stringify(details);
+      } catch {
+        serialized = JSON.stringify({ unserializable: true });
+      }
+      if (serialized && serialized.length > MAX_AUDIT_DETAILS_BYTES) {
+        serialized = JSON.stringify({ truncated: true, originalKeys: Object.keys(details) });
+      }
+      detailsJson = serialized;
+    }
+    insertAuditStmt.run(
+      Date.now(),
+      String(type),
+      resolvedActor || null,
+      target ?? null,
+      detailsJson,
+      req?.ip || null,
+      req?.headers?.['user-agent'] || null
+    );
+  } catch (err) {
+    console.error('[audit] logEvent failed:', err.message);
+  }
+}
+
 // Register
 app.post('/api/register', async (req, res) => {
   const { username: rawUsername, password, inviteToken } = req.body;
 
   if (!rawUsername || !password) {
+    logEvent(req, { type: 'auth.register.failure', actor: null, target: null, details: { reason: 'missing_credentials' } });
     return res.status(400).json({ error: 'Username and password required' });
   }
 
   const username = String(rawUsername).trim().toLowerCase();
   if (!EMAIL_REGEX.test(username)) {
+    logEvent(req, { type: 'auth.register.failure', actor: username, target: username, details: { reason: 'invalid_email' } });
     return res.status(400).json({ error: 'Username must be a valid email address' });
   }
 
   if (!inviteToken) {
+    logEvent(req, { type: 'auth.register.failure', actor: username, target: username, details: { reason: 'missing_invite_token' } });
     return res.status(400).json({ error: 'Invite token required' });
   }
 
   // Validate invite token
   const invite = db.prepare('SELECT * FROM invite_tokens WHERE token = ?').get(inviteToken);
   if (!invite) {
+    logEvent(req, { type: 'auth.register.failure', actor: username, target: username, details: { reason: 'invalid_token' } });
     return res.status(400).json({ error: 'Invalid invite token' });
   }
   if (invite.used_by) {
+    logEvent(req, { type: 'auth.register.failure', actor: username, target: username, details: { reason: 'token_used' } });
     return res.status(400).json({ error: 'Invite token has already been used' });
   }
   if (invite.revoked) {
+    logEvent(req, { type: 'auth.register.failure', actor: username, target: username, details: { reason: 'token_revoked' } });
     return res.status(400).json({ error: 'Invite token has been revoked' });
   }
 
   const existing = db.prepare('SELECT username FROM users WHERE username = ? COLLATE NOCASE').get(username);
   if (existing) {
+    logEvent(req, { type: 'auth.register.failure', actor: username, target: username, details: { reason: 'username_exists' } });
     return res.status(400).json({ error: 'Username already exists' });
   }
 
@@ -275,8 +343,11 @@ app.post('/api/register', async (req, res) => {
   try {
     createUser();
   } catch (err) {
+    logEvent(req, { type: 'auth.register.failure', actor: username, target: username, details: { reason: 'race_lost' } });
     return res.status(400).json({ error: err.message });
   }
+
+  logEvent(req, { type: 'auth.register.success', actor: username, target: username, details: { inviteTokenPrefix: String(inviteToken).slice(0, 8) } });
 
   res.json({
     username,
@@ -294,6 +365,7 @@ app.post('/api/login', async (req, res) => {
   const { username: rawUsername, password } = req.body;
 
   if (!rawUsername || !password) {
+    logEvent(req, { type: 'auth.login.failure', actor: null, target: null, details: { reason: 'missing_credentials' } });
     return res.status(401).json({ error: 'Invalid username or password' });
   }
 
@@ -301,13 +373,17 @@ app.post('/api/login', async (req, res) => {
   const user = db.prepare('SELECT * FROM users WHERE username = ? COLLATE NOCASE').get(lookup);
 
   if (!user) {
+    logEvent(req, { type: 'auth.login.failure', actor: lookup, target: lookup, details: { reason: 'no_user' } });
     return res.status(401).json({ error: 'Invalid username or password' });
   }
 
   const passwordMatch = await bcrypt.compare(password, user.password);
   if (!passwordMatch) {
+    logEvent(req, { type: 'auth.login.failure', actor: user.username, target: user.username, details: { reason: 'bad_password' } });
     return res.status(401).json({ error: 'Invalid username or password' });
   }
+
+  logEvent(req, { type: 'auth.login.success', actor: user.username, target: user.username });
 
   res.json({
     ...formatUserSession(user),
@@ -390,6 +466,7 @@ app.post('/api/migrate-username', async (req, res) => {
   }
 
   const updated = db.prepare('SELECT * FROM users WHERE username = ?').get(newUsername);
+  logEvent(req, { type: 'auth.username.migrated', actor: newUsername, target: newUsername, details: { from: user.username } });
   res.json(formatUserSession(updated));
 });
 
@@ -435,6 +512,16 @@ app.put('/api/user/:username', (req, res) => {
     WHERE username = ?
   `).run(updates.fullName, updates.location, updates.latitude, updates.longitude, updates.markerColor, updates.birthday, updates.displayName, username);
 
+  const changedFields = [];
+  if (fullName !== undefined && fullName !== (user.fullName || '')) changedFields.push('fullName');
+  if (location !== undefined && location !== user.location) changedFields.push('location');
+  if (coordinates?.lat !== undefined && coordinates.lat !== user.latitude) changedFields.push('coordinates');
+  if (coordinates?.lng !== undefined && coordinates.lng !== user.longitude && !changedFields.includes('coordinates')) changedFields.push('coordinates');
+  if (markerColor !== undefined && validMarkerColor !== (user.markerColor || 'red')) changedFields.push('markerColor');
+  if (birthday !== undefined && birthday !== (user.birthday || '')) changedFields.push('birthday');
+  if (displayName !== undefined && displayName !== (user.display_name || '')) changedFields.push('displayName');
+  logEvent(req, { type: 'user.profile.updated', target: username, details: { changedFields } });
+
   const updated = db.prepare('SELECT * FROM users WHERE username = ?').get(username);
   res.json(formatUserSession(updated));
 });
@@ -452,11 +539,13 @@ app.put('/api/user/:username/password', async (req, res) => {
 
   const passwordMatch = await bcrypt.compare(currentPassword, user.password);
   if (!passwordMatch) {
+    logEvent(req, { type: 'auth.password.change_failed', actor: username, target: username, details: { reason: 'bad_current_password' } });
     return res.status(401).json({ error: 'Current password is incorrect' });
   }
 
   const hashedPassword = await bcrypt.hash(newPassword, SALT_ROUNDS);
   db.prepare('UPDATE users SET password = ? WHERE username = ?').run(hashedPassword, username);
+  logEvent(req, { type: 'auth.password.changed', actor: username, target: username });
 
   res.json({ success: true });
 });
@@ -472,18 +561,21 @@ app.post('/api/reset-password', async (req, res) => {
   const user = db.prepare('SELECT * FROM users WHERE resetToken = ?').get(token);
 
   if (!user) {
+    logEvent(req, { type: 'auth.password.reset_token_invalid', actor: null, target: null, details: { reason: 'unknown_token' } });
     return res.status(400).json({ error: 'Invalid or expired reset token' });
   }
 
   if (user.resetTokenExpires && user.resetTokenExpires < Date.now()) {
     // Clear expired token
     db.prepare('UPDATE users SET resetToken = NULL, resetTokenExpires = NULL WHERE username = ?').run(user.username);
+    logEvent(req, { type: 'auth.password.reset_token_invalid', actor: user.username, target: user.username, details: { reason: 'expired_token' } });
     return res.status(400).json({ error: 'Reset token has expired' });
   }
 
   const hashedPassword = await bcrypt.hash(newPassword, SALT_ROUNDS);
   db.prepare('UPDATE users SET password = ?, resetToken = NULL, resetTokenExpires = NULL WHERE username = ?')
     .run(hashedPassword, user.username);
+  logEvent(req, { type: 'auth.password.reset_via_token', actor: user.username, target: user.username });
 
   res.json({ success: true, message: 'Password has been reset' });
 });
@@ -543,6 +635,7 @@ app.post('/api/user/:username/photo', upload.single('photo'), (req, res) => {
 
   const photoUrl = `/uploads/${req.file.filename}`;
   db.prepare('UPDATE users SET profilePhoto = ? WHERE username = ?').run(photoUrl, username);
+  logEvent(req, { type: 'user.photo.uploaded', target: username, details: { filename: req.file.filename, sizeBytes: req.file.size } });
 
   res.json({ success: true, profilePhoto: photoUrl });
 });
@@ -564,6 +657,7 @@ app.delete('/api/user/:username/photo', (req, res) => {
   }
 
   db.prepare('UPDATE users SET profilePhoto = NULL WHERE username = ?').run(username);
+  logEvent(req, { type: 'user.photo.deleted', target: username });
   res.json({ success: true });
 });
 
@@ -588,6 +682,7 @@ app.delete('/api/admin/user/:username', requireAdmin, (req, res) => {
   }
 
   db.prepare('DELETE FROM users WHERE username = ?').run(username);
+  logEvent(req, { type: 'admin.user.deleted', target: username });
   res.json({ success: true });
 });
 
@@ -596,12 +691,13 @@ app.put('/api/admin/user/:username/admin', requireAdmin, (req, res) => {
   const { username } = req.params;
   const { isAdmin } = req.body;
 
-  const user = db.prepare('SELECT username FROM users WHERE username = ?').get(username);
+  const user = db.prepare('SELECT username, isAdmin FROM users WHERE username = ?').get(username);
   if (!user) {
     return res.status(404).json({ error: 'User not found' });
   }
 
   db.prepare('UPDATE users SET isAdmin = ? WHERE username = ?').run(isAdmin ? 1 : 0, username);
+  logEvent(req, { type: 'admin.user.role_changed', target: username, details: { from: !!user.isAdmin, to: !!isAdmin } });
   res.json({ success: true, username, isAdmin: !!isAdmin });
 });
 
@@ -619,6 +715,7 @@ app.post('/api/admin/user/:username/reset-token', requireAdmin, (req, res) => {
 
   db.prepare('UPDATE users SET resetToken = ?, resetTokenExpires = ? WHERE username = ?')
     .run(resetToken, resetTokenExpires, username);
+  logEvent(req, { type: 'admin.password.reset_link_generated', target: username, details: { expiresAt: new Date(resetTokenExpires).toISOString() } });
 
   res.json({
     success: true,
@@ -681,6 +778,7 @@ app.post('/api/admin/import', requireAdmin, async (req, res) => {
   }
 
   const count = db.prepare('SELECT COUNT(*) as count FROM users').get().count;
+  logEvent(req, { type: 'admin.users.imported', details: { mode: mode || 'merge', count } });
   res.json({ success: true, count });
 });
 
@@ -689,6 +787,7 @@ app.post('/api/invite', requireAuth, (req, res) => {
   const token = crypto.randomBytes(32).toString('hex');
   db.prepare('INSERT INTO invite_tokens (token, created_by, created_at) VALUES (?, ?, ?)')
     .run(token, req.user.username, Date.now());
+  logEvent(req, { type: 'invite.created', actor: req.user.username, target: req.user.username, details: { tokenPrefix: token.slice(0, 8) } });
   res.json({ token });
 });
 
@@ -716,8 +815,50 @@ app.delete('/api/admin/invite/:token', requireAdmin, (req, res) => {
     return res.status(400).json({ error: 'Cannot revoke a used token' });
   }
   db.prepare('UPDATE invite_tokens SET revoked = 1 WHERE token = ?').run(token);
+  logEvent(req, { type: 'invite.revoked', target: invite.created_by, details: { tokenPrefix: token.slice(0, 8) } });
   res.json({ success: true });
 });
+
+// Admin: Audit log query
+app.get('/api/admin/audit', requireAdmin, (req, res) => {
+  const limit = Math.min(Math.max(parseInt(req.query.limit, 10) || 50, 1), 200);
+  const offset = Math.max(parseInt(req.query.offset, 10) || 0, 0);
+  const { actor, target, eventType, dateFrom, dateTo } = req.query;
+
+  const where = [];
+  const args = [];
+  if (actor)     { where.push('actor LIKE ?');   args.push(`%${actor}%`); }
+  if (target)    { where.push('target LIKE ?');  args.push(`%${target}%`); }
+  if (eventType) { where.push('event_type = ?'); args.push(eventType); }
+  if (dateFrom)  { const t = parseInt(dateFrom, 10); if (!isNaN(t)) { where.push('timestamp >= ?'); args.push(t); } }
+  if (dateTo)    { const t = parseInt(dateTo, 10);   if (!isNaN(t)) { where.push('timestamp <= ?'); args.push(t); } }
+  const whereSql = where.length ? `WHERE ${where.join(' AND ')}` : '';
+
+  const total = db.prepare(`SELECT COUNT(*) AS c FROM audit_events ${whereSql}`).get(...args).c;
+  const rows = db.prepare(
+    `SELECT id, timestamp, event_type, actor, target, details, ip, user_agent
+     FROM audit_events ${whereSql}
+     ORDER BY timestamp DESC, id DESC
+     LIMIT ? OFFSET ?`
+  ).all(...args, limit, offset);
+
+  const events = rows.map(r => ({
+    id: r.id,
+    timestamp: r.timestamp,
+    eventType: r.event_type,
+    actor: r.actor,
+    target: r.target,
+    details: r.details ? safeParseJson(r.details) : null,
+    ip: r.ip,
+    userAgent: r.user_agent,
+  }));
+
+  res.json({ events, total, limit, offset });
+});
+
+function safeParseJson(s) {
+  try { return JSON.parse(s); } catch { return { _raw: s }; }
+}
 
 // Admin: Export calendar events
 app.get('/api/admin/events/export', requireAdmin, (req, res) => {
@@ -921,6 +1062,7 @@ app.post('/api/admin/events/import', requireAdmin, (req, res) => {
   });
   tx();
   const count = db.prepare('SELECT COUNT(*) as count FROM calendar_events').get().count;
+  logEvent(req, { type: 'admin.events.imported', details: { mode: mode || 'merge', count } });
   res.json({ success: true, count });
 });
 
@@ -1115,6 +1257,7 @@ app.post('/api/events', requireAuth, (req, res) => {
     now
   );
   const event = db.prepare('SELECT * FROM calendar_events WHERE id = ?').get(result.lastInsertRowid);
+  logEvent(req, { type: 'event.created', target: String(event.id), details: { title: event.title, visibility: event.visibility } });
   res.json(event);
 });
 
@@ -1131,6 +1274,15 @@ app.put('/api/events/:id', requireAuth, (req, res) => {
   if (visibility && !['community', 'personal'].includes(visibility)) {
     return res.status(400).json({ error: 'visibility must be community or personal' });
   }
+  const changedFields = [];
+  if (title !== undefined && title !== event.title) changedFields.push('title');
+  if (event_date !== undefined && event_date !== event.event_date) changedFields.push('event_date');
+  if (event_time !== undefined && (event_time || null) !== event.event_time) changedFields.push('event_time');
+  if (end_date !== undefined && end_date !== (event.end_date || '')) changedFields.push('end_date');
+  if (description !== undefined && description !== event.description) changedFields.push('description');
+  if (location !== undefined && location !== event.location) changedFields.push('location');
+  if (visibility !== undefined && visibility !== event.visibility) changedFields.push('visibility');
+  if (recurrence !== undefined && recurrence !== event.recurrence) changedFields.push('recurrence');
   db.prepare(
     `UPDATE calendar_events SET title = ?, event_date = ?, event_time = ?, end_date = ?, description = ?, location = ?, visibility = ?, recurrence = ?, updated_at = ?
      WHERE id = ?`
@@ -1147,6 +1299,7 @@ app.put('/api/events/:id', requireAuth, (req, res) => {
     req.params.id
   );
   const updated = db.prepare('SELECT * FROM calendar_events WHERE id = ?').get(req.params.id);
+  logEvent(req, { type: 'event.updated', target: String(event.id), details: { changedFields } });
   res.json(updated);
 });
 
@@ -1160,6 +1313,7 @@ app.delete('/api/events/:id', requireAuth, (req, res) => {
     return res.status(403).json({ error: 'Only the creator or admin can delete' });
   }
   db.prepare('DELETE FROM calendar_events WHERE id = ?').run(req.params.id);
+  logEvent(req, { type: 'event.deleted', target: String(event.id), details: { title: event.title } });
   res.json({ success: true });
 });
 

--- a/src/api.js
+++ b/src/api.js
@@ -242,6 +242,25 @@ export const api = {
     return res.json();
   },
 
+  async getAuditEvents(params = {}) {
+    const qs = new URLSearchParams();
+    if (params.actor)     qs.set('actor', params.actor);
+    if (params.target)    qs.set('target', params.target);
+    if (params.eventType) qs.set('eventType', params.eventType);
+    if (params.dateFrom != null) qs.set('dateFrom', String(params.dateFrom));
+    if (params.dateTo   != null) qs.set('dateTo',   String(params.dateTo));
+    if (params.limit    != null) qs.set('limit',    String(params.limit));
+    if (params.offset   != null) qs.set('offset',   String(params.offset));
+    const res = await fetch(`${API_BASE}/admin/audit?${qs.toString()}`, {
+      headers: getAuthHeaders(),
+    });
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}));
+      throw new Error(data.error || 'Failed to load audit events');
+    }
+    return res.json();
+  },
+
   async revokeInvite(token) {
     const res = await fetch(`${API_BASE}/admin/invite/${token}`, {
       method: 'DELETE',

--- a/src/pages/AdminDashboard.jsx
+++ b/src/pages/AdminDashboard.jsx
@@ -23,6 +23,8 @@ import {
   Radio,
   RadioGroup,
   FormLabel,
+  Tabs,
+  Tab,
 } from '@mui/material';
 import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/Delete';
@@ -35,6 +37,7 @@ import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import { useAuth } from '../contexts/AuthContext';
 import { Navigate } from 'react-router-dom';
 import { api } from '../api';
+import AuditLogTab from './admin/AuditLogTab';
 
 function AdminDashboard() {
   const { user, isAdmin } = useAuth();
@@ -59,6 +62,7 @@ function AdminDashboard() {
   const [resetLinkCopied, setResetLinkCopied] = useState(false);
   const fileInputRef = useRef(null);
   const calendarFileInputRef = useRef(null);
+  const [activeTab, setActiveTab] = useState(0);
 
   useEffect(() => {
     loadUsers();
@@ -305,30 +309,6 @@ function AdminDashboard() {
           color="primary"
           size="small"
         />
-        <Box sx={{ flexGrow: 1 }} />
-        <Button
-          variant="outlined"
-          startIcon={<DownloadIcon />}
-          onClick={handleExport}
-          size="small"
-        >
-          Export
-        </Button>
-        <Button
-          variant="outlined"
-          startIcon={<UploadIcon />}
-          onClick={handleImportClick}
-          size="small"
-        >
-          Import
-        </Button>
-        <input
-          type="file"
-          ref={fileInputRef}
-          onChange={handleFileSelect}
-          accept=".json"
-          style={{ display: 'none' }}
-        />
       </Box>
 
       {success && (
@@ -343,63 +323,76 @@ function AdminDashboard() {
         </Alert>
       )}
 
-      <Paper>
-        <TableContainer>
-          <Table>
-            <TableHead>
-              <TableRow>
-                <TableCell>Username</TableCell>
-                <TableCell>Full Name</TableCell>
-                <TableCell>Location</TableCell>
-                <TableCell align="right">Actions</TableCell>
-              </TableRow>
-            </TableHead>
-            <TableBody>
-              {users.map((u) => (
-                <TableRow key={u.username}>
-                  <TableCell>{u.username}</TableCell>
-                  <TableCell>{u.fullName || '-'}</TableCell>
-                  <TableCell>{u.location || '-'}</TableCell>
-                  <TableCell align="right">
-                    <IconButton
-                      color="primary"
-                      onClick={() => handleEditClick(u)}
-                      size="small"
-                      title="Edit user"
-                    >
-                      <EditIcon />
-                    </IconButton>
-                    <IconButton
-                      color="warning"
-                      onClick={() => handleGenerateResetLink(u)}
-                      size="small"
-                      title="Generate password reset link"
-                    >
-                      <LockResetIcon />
-                    </IconButton>
-                    <IconButton
-                      color="error"
-                      onClick={() => handleDeleteClick(u)}
-                      size="small"
-                      disabled={u.username === user.username}
-                      title="Delete user"
-                    >
-                      <DeleteIcon />
-                    </IconButton>
-                  </TableCell>
-                </TableRow>
-              ))}
-              {users.length === 0 && (
+      <Tabs
+        value={activeTab}
+        onChange={(_, v) => setActiveTab(v)}
+        sx={{ mb: 2, borderBottom: 1, borderColor: 'divider' }}
+      >
+        <Tab label="Users" />
+        <Tab label="Invites" />
+        <Tab label="Backup" />
+        <Tab label="Activity" />
+      </Tabs>
+
+      {activeTab === 0 && (
+        <Paper>
+          <TableContainer>
+            <Table>
+              <TableHead>
                 <TableRow>
-                  <TableCell colSpan={4} align="center">
-                    No users found
-                  </TableCell>
+                  <TableCell>Username</TableCell>
+                  <TableCell>Full Name</TableCell>
+                  <TableCell>Location</TableCell>
+                  <TableCell align="right">Actions</TableCell>
                 </TableRow>
-              )}
-            </TableBody>
-          </Table>
-        </TableContainer>
-      </Paper>
+              </TableHead>
+              <TableBody>
+                {users.map((u) => (
+                  <TableRow key={u.username}>
+                    <TableCell>{u.username}</TableCell>
+                    <TableCell>{u.fullName || '-'}</TableCell>
+                    <TableCell>{u.location || '-'}</TableCell>
+                    <TableCell align="right">
+                      <IconButton
+                        color="primary"
+                        onClick={() => handleEditClick(u)}
+                        size="small"
+                        title="Edit user"
+                      >
+                        <EditIcon />
+                      </IconButton>
+                      <IconButton
+                        color="warning"
+                        onClick={() => handleGenerateResetLink(u)}
+                        size="small"
+                        title="Generate password reset link"
+                      >
+                        <LockResetIcon />
+                      </IconButton>
+                      <IconButton
+                        color="error"
+                        onClick={() => handleDeleteClick(u)}
+                        size="small"
+                        disabled={u.username === user.username}
+                        title="Delete user"
+                      >
+                        <DeleteIcon />
+                      </IconButton>
+                    </TableCell>
+                  </TableRow>
+                ))}
+                {users.length === 0 && (
+                  <TableRow>
+                    <TableCell colSpan={4} align="center">
+                      No users found
+                    </TableCell>
+                  </TableRow>
+                )}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        </Paper>
+      )}
 
       {/* Edit Dialog */}
       <Dialog open={editDialogOpen} onClose={() => setEditDialogOpen(false)} maxWidth="sm" fullWidth>
@@ -514,65 +507,63 @@ function AdminDashboard() {
         </DialogActions>
       </Dialog>
 
-      {/* Invite Tokens Section */}
-      <Typography variant="h6" sx={{ mt: 4, mb: 2 }}>
-        Invite Tokens
-      </Typography>
-      <Paper>
-        <TableContainer>
-          <Table>
-            <TableHead>
-              <TableRow>
-                <TableCell>Token</TableCell>
-                <TableCell>Created By</TableCell>
-                <TableCell>Created At</TableCell>
-                <TableCell>Status</TableCell>
-                <TableCell>Used By</TableCell>
-                <TableCell align="right">Actions</TableCell>
-              </TableRow>
-            </TableHead>
-            <TableBody>
-              {invites.map((invite) => {
-                const status = getInviteStatus(invite);
-                return (
-                  <TableRow key={invite.token}>
-                    <TableCell>
-                      <Typography variant="body2" sx={{ fontFamily: 'monospace' }}>
-                        {invite.token.substring(0, 16)}...
-                      </Typography>
-                    </TableCell>
-                    <TableCell>{invite.created_by}</TableCell>
-                    <TableCell>{new Date(invite.created_at).toLocaleDateString()}</TableCell>
-                    <TableCell>
-                      <Chip label={status.label} color={status.color} size="small" />
-                    </TableCell>
-                    <TableCell>{invite.used_by || '-'}</TableCell>
-                    <TableCell align="right">
-                      {!invite.used_by && !invite.revoked && (
-                        <IconButton
-                          color="error"
-                          onClick={() => handleRevokeClick(invite)}
-                          size="small"
-                          title="Revoke"
-                        >
-                          <BlockIcon />
-                        </IconButton>
-                      )}
+      {activeTab === 1 && (
+        <Paper>
+          <TableContainer>
+            <Table>
+              <TableHead>
+                <TableRow>
+                  <TableCell>Token</TableCell>
+                  <TableCell>Created By</TableCell>
+                  <TableCell>Created At</TableCell>
+                  <TableCell>Status</TableCell>
+                  <TableCell>Used By</TableCell>
+                  <TableCell align="right">Actions</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {invites.map((invite) => {
+                  const status = getInviteStatus(invite);
+                  return (
+                    <TableRow key={invite.token}>
+                      <TableCell>
+                        <Typography variant="body2" sx={{ fontFamily: 'monospace' }}>
+                          {invite.token.substring(0, 16)}...
+                        </Typography>
+                      </TableCell>
+                      <TableCell>{invite.created_by}</TableCell>
+                      <TableCell>{new Date(invite.created_at).toLocaleDateString()}</TableCell>
+                      <TableCell>
+                        <Chip label={status.label} color={status.color} size="small" />
+                      </TableCell>
+                      <TableCell>{invite.used_by || '-'}</TableCell>
+                      <TableCell align="right">
+                        {!invite.used_by && !invite.revoked && (
+                          <IconButton
+                            color="error"
+                            onClick={() => handleRevokeClick(invite)}
+                            size="small"
+                            title="Revoke"
+                          >
+                            <BlockIcon />
+                          </IconButton>
+                        )}
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+                {invites.length === 0 && (
+                  <TableRow>
+                    <TableCell colSpan={6} align="center">
+                      No invite tokens found
                     </TableCell>
                   </TableRow>
-                );
-              })}
-              {invites.length === 0 && (
-                <TableRow>
-                  <TableCell colSpan={6} align="center">
-                    No invite tokens found
-                  </TableCell>
-                </TableRow>
-              )}
-            </TableBody>
-          </Table>
-        </TableContainer>
-      </Paper>
+                )}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        </Paper>
+      )}
 
       {/* Revoke Dialog */}
       <Dialog open={revokeDialogOpen} onClose={() => setRevokeDialogOpen(false)}>
@@ -590,37 +581,68 @@ function AdminDashboard() {
         </DialogActions>
       </Dialog>
 
-      {/* Calendar Backup Section */}
-      <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mt: 4, mb: 2, flexWrap: 'wrap' }}>
-        <CalendarMonthIcon color="primary" />
-        <Typography variant="h6">
-          Calendar Backup
-        </Typography>
-        <Box sx={{ flexGrow: 1 }} />
-        <Button
-          variant="outlined"
-          startIcon={<DownloadIcon />}
-          onClick={handleCalendarExport}
-          size="small"
-        >
-          Export Events
-        </Button>
-        <Button
-          variant="outlined"
-          startIcon={<UploadIcon />}
-          onClick={handleCalendarImportClick}
-          size="small"
-        >
-          Import Events
-        </Button>
-        <input
-          type="file"
-          ref={calendarFileInputRef}
-          onChange={handleCalendarFileSelect}
-          accept=".json"
-          style={{ display: 'none' }}
-        />
-      </Box>
+      {activeTab === 2 && (
+        <Box>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 2, flexWrap: 'wrap' }}>
+            <Typography variant="h6">Users</Typography>
+            <Box sx={{ flexGrow: 1 }} />
+            <Button
+              variant="outlined"
+              startIcon={<DownloadIcon />}
+              onClick={handleExport}
+              size="small"
+            >
+              Export Users
+            </Button>
+            <Button
+              variant="outlined"
+              startIcon={<UploadIcon />}
+              onClick={handleImportClick}
+              size="small"
+            >
+              Import Users
+            </Button>
+          </Box>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mt: 4, mb: 2, flexWrap: 'wrap' }}>
+            <CalendarMonthIcon color="primary" />
+            <Typography variant="h6">Calendar Events</Typography>
+            <Box sx={{ flexGrow: 1 }} />
+            <Button
+              variant="outlined"
+              startIcon={<DownloadIcon />}
+              onClick={handleCalendarExport}
+              size="small"
+            >
+              Export Events
+            </Button>
+            <Button
+              variant="outlined"
+              startIcon={<UploadIcon />}
+              onClick={handleCalendarImportClick}
+              size="small"
+            >
+              Import Events
+            </Button>
+          </Box>
+        </Box>
+      )}
+
+      {activeTab === 3 && <AuditLogTab />}
+
+      <input
+        type="file"
+        ref={fileInputRef}
+        onChange={handleFileSelect}
+        accept=".json"
+        style={{ display: 'none' }}
+      />
+      <input
+        type="file"
+        ref={calendarFileInputRef}
+        onChange={handleCalendarFileSelect}
+        accept=".json"
+        style={{ display: 'none' }}
+      />
 
       {/* Calendar Import Dialog */}
       <Dialog open={calendarImportDialogOpen} onClose={() => setCalendarImportDialogOpen(false)} maxWidth="sm" fullWidth>

--- a/src/pages/admin/AuditLogTab.jsx
+++ b/src/pages/admin/AuditLogTab.jsx
@@ -1,0 +1,217 @@
+import { useState, useEffect, useCallback } from 'react';
+import {
+  Box, Paper, Table, TableBody, TableCell, TableContainer, TableHead, TableRow,
+  TablePagination, TextField, MenuItem, Stack, Tooltip, Typography, Alert, Button,
+} from '@mui/material';
+import { api } from '../../api';
+
+const AUDIT_EVENT_TYPES = [
+  'auth.login.success',
+  'auth.login.failure',
+  'auth.register.success',
+  'auth.register.failure',
+  'auth.username.migrated',
+  'auth.password.changed',
+  'auth.password.change_failed',
+  'auth.password.reset_via_token',
+  'auth.password.reset_token_invalid',
+  'user.profile.updated',
+  'user.photo.uploaded',
+  'user.photo.deleted',
+  'admin.user.deleted',
+  'admin.user.role_changed',
+  'admin.password.reset_link_generated',
+  'admin.users.imported',
+  'admin.events.imported',
+  'invite.created',
+  'invite.revoked',
+  'event.created',
+  'event.updated',
+  'event.deleted',
+];
+
+const EMPTY_FILTERS = { actor: '', target: '', eventType: '', dateFrom: '', dateTo: '' };
+
+function AuditLogTab() {
+  const [events, setEvents] = useState([]);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(0);
+  const [rowsPerPage, setRowsPerPage] = useState(50);
+  const [filters, setFilters] = useState(EMPTY_FILTERS);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError('');
+    try {
+      const params = {
+        limit: rowsPerPage,
+        offset: page * rowsPerPage,
+        ...(filters.actor && { actor: filters.actor }),
+        ...(filters.target && { target: filters.target }),
+        ...(filters.eventType && { eventType: filters.eventType }),
+        ...(filters.dateFrom && { dateFrom: new Date(filters.dateFrom).getTime() }),
+        ...(filters.dateTo && { dateTo: new Date(filters.dateTo).getTime() }),
+      };
+      const data = await api.getAuditEvents(params);
+      setEvents(data.events);
+      setTotal(data.total);
+    } catch (e) {
+      setError(e.message);
+    } finally {
+      setLoading(false);
+    }
+  }, [page, rowsPerPage, filters]);
+
+  useEffect(() => { load(); }, [load]);
+
+  const handleFilterChange = (key) => (e) => {
+    setFilters((f) => ({ ...f, [key]: e.target.value }));
+    setPage(0);
+  };
+
+  const handleClearFilters = () => {
+    setFilters(EMPTY_FILTERS);
+    setPage(0);
+  };
+
+  const hasFilters = Object.values(filters).some(Boolean);
+
+  return (
+    <Box>
+      <Stack
+        direction={{ xs: 'column', md: 'row' }}
+        spacing={2}
+        sx={{ mb: 2 }}
+        alignItems={{ md: 'center' }}
+        flexWrap="wrap"
+      >
+        <TextField
+          label="Actor"
+          size="small"
+          value={filters.actor}
+          onChange={handleFilterChange('actor')}
+          placeholder="username substring"
+        />
+        <TextField
+          label="Target"
+          size="small"
+          value={filters.target}
+          onChange={handleFilterChange('target')}
+          placeholder="username / id substring"
+        />
+        <TextField
+          select
+          label="Event Type"
+          size="small"
+          value={filters.eventType}
+          onChange={handleFilterChange('eventType')}
+          sx={{ minWidth: 240 }}
+        >
+          <MenuItem value="">All</MenuItem>
+          {AUDIT_EVENT_TYPES.map((t) => (
+            <MenuItem key={t} value={t}>{t}</MenuItem>
+          ))}
+        </TextField>
+        <TextField
+          label="From"
+          type="datetime-local"
+          size="small"
+          InputLabelProps={{ shrink: true }}
+          value={filters.dateFrom}
+          onChange={handleFilterChange('dateFrom')}
+        />
+        <TextField
+          label="To"
+          type="datetime-local"
+          size="small"
+          InputLabelProps={{ shrink: true }}
+          value={filters.dateTo}
+          onChange={handleFilterChange('dateTo')}
+        />
+        {hasFilters && (
+          <Button size="small" onClick={handleClearFilters}>Clear filters</Button>
+        )}
+      </Stack>
+
+      {error && (
+        <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError('')}>
+          {error}
+        </Alert>
+      )}
+
+      <Paper>
+        <TableContainer>
+          <Table size="small" stickyHeader>
+            <TableHead>
+              <TableRow>
+                <TableCell sx={{ whiteSpace: 'nowrap' }}>Timestamp</TableCell>
+                <TableCell>Type</TableCell>
+                <TableCell>Actor</TableCell>
+                <TableCell>Target</TableCell>
+                <TableCell>Details</TableCell>
+                <TableCell sx={{ whiteSpace: 'nowrap' }}>IP</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {events.map((ev) => (
+                <TableRow key={ev.id} hover>
+                  <TableCell sx={{ whiteSpace: 'nowrap', fontFamily: 'monospace', fontSize: '0.78rem' }}>
+                    {new Date(ev.timestamp).toLocaleString()}
+                  </TableCell>
+                  <TableCell sx={{ fontFamily: 'monospace', fontSize: '0.78rem' }}>
+                    {ev.eventType}
+                  </TableCell>
+                  <TableCell sx={{ fontSize: '0.85rem' }}>{ev.actor || '—'}</TableCell>
+                  <TableCell sx={{ fontSize: '0.85rem' }}>{ev.target || '—'}</TableCell>
+                  <TableCell>
+                    <Tooltip title={ev.userAgent || ''} placement="top">
+                      <Typography
+                        component="span"
+                        variant="body2"
+                        sx={{
+                          fontFamily: 'monospace',
+                          fontSize: '0.72rem',
+                          whiteSpace: 'pre-wrap',
+                          wordBreak: 'break-all',
+                          color: 'text.secondary',
+                        }}
+                      >
+                        {ev.details ? JSON.stringify(ev.details) : '—'}
+                      </Typography>
+                    </Tooltip>
+                  </TableCell>
+                  <TableCell sx={{ fontFamily: 'monospace', fontSize: '0.78rem' }}>
+                    {ev.ip || '—'}
+                  </TableCell>
+                </TableRow>
+              ))}
+              {!loading && events.length === 0 && (
+                <TableRow>
+                  <TableCell colSpan={6} align="center" sx={{ color: 'text.secondary' }}>
+                    {hasFilters ? 'No events match these filters.' : 'No audit events recorded yet.'}
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+        </TableContainer>
+        <TablePagination
+          component="div"
+          count={total}
+          page={page}
+          onPageChange={(_, p) => setPage(p)}
+          rowsPerPage={rowsPerPage}
+          onRowsPerPageChange={(e) => {
+            setRowsPerPage(parseInt(e.target.value, 10));
+            setPage(0);
+          }}
+          rowsPerPageOptions={[25, 50, 100, 200]}
+        />
+      </Paper>
+    </Box>
+  );
+}
+
+export default AuditLogTab;


### PR DESCRIPTION
## Summary

Implements #19. Adds an audit log for security and data-mutating actions, persisted to a new `audit_events` SQLite table and exposed through a new **Activity** tab in the existing admin dashboard. Existing admin sections are reorganized into tabs along the way.

Broken into 4 commits for review:

1. `feat(api)` — backend: schema, helper, `app.set('trust proxy', 'loopback')`, 22 instrumentation points, and the `GET /api/admin/audit` query endpoint.
2. `feat(api)` — `getAuditEvents` client method in `src/api.js`.
3. `feat(admin)` — `AuditLogTab` component (sticky-header table, pagination, 5 filter inputs).
4. `refactor(admin)` — split `AdminDashboard` into Users / Invites / Backup / Activity tabs.

## Notes

- **Trust proxy** is set to `'loopback'` (not `true`) so only `127.0.0.1` / `::1` upstreams are trusted to forward `X-Forwarded-For`. Verify Nginx forwards the header (`proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;` is in the standard upstream block).
- **PII guarantees**: reset tokens, invite tokens, and bcrypt hashes never appear in `details`. Invite tokens reduce to `tokenPrefix` (8 chars). Passwords from `req.body` are never inserted.
- **Failure isolation**: `logEvent` is wrapped in try/catch — a logging error never breaks the parent request; errors print to stderr only.
- **Details size cap**: 4KB soft cap; on overflow we replace with `{ truncated: true, originalKeys: [...] }` to avoid runaway rows.
- **Read-only admin endpoints are intentionally not logged** (`/api/admin/users`, `/api/admin/invites`, `/api/admin/export`, `/api/admin/events/export`, `/api/admin/audit` itself). Justification: every admin page load triggers several of these, and self-logging the audit fetch would create infinite scroll noise. Nginx access logs cover GET exfil if needed. Worth filing a follow-up if we want `admin.users.exported` for the bulk-export specifically.
- **Retention** is out of scope per the issue. The schema is forward-compatible with a future cron job (`DELETE FROM audit_events WHERE timestamp < ?`).

## Instrumented event types (22)

`auth.login.success` · `auth.login.failure` · `auth.register.success` · `auth.register.failure` · `auth.username.migrated` · `auth.password.changed` · `auth.password.change_failed` · `auth.password.reset_via_token` · `auth.password.reset_token_invalid` · `user.profile.updated` · `user.photo.uploaded` · `user.photo.deleted` · `admin.user.deleted` · `admin.user.role_changed` · `admin.password.reset_link_generated` · `admin.users.imported` · `admin.events.imported` · `invite.created` · `invite.revoked` · `event.created` · `event.updated` · `event.deleted`

## Test plan

- [x] Cold start: `audit_events` table is created with the 4 expected indexes.
- [x] Log in successfully → `auth.login.success` appears in the Activity tab with correct actor / target / IP / user-agent.
- [x] Log in with a wrong password → `auth.login.failure` reason `bad_password`.
- [x] Log in with an unknown user → `auth.login.failure` reason `no_user`; the attempted username is captured as actor.
- [x] Register with a bad invite token → `auth.register.failure` with the right reason; on success → `auth.register.success` with `inviteTokenPrefix` (8 chars only).
- [x] Update only `fullName` on Profile → `user.profile.updated` with `details.changedFields === ['fullName']`.
- [x] Promote a user via admin → `admin.user.role_changed` with `from:false, to:true`.
- [x] Generate an admin reset link → row exists; verify the actual `resetToken` value does NOT appear in `details`.
- [x] Activity tab loads with 50 most-recent rows, newest first.
- [x] Filter by actor substring → only matching rows; pagination total reflects filter.
- [x] Filter by event type → exact match.
- [x] Date range narrows the result set correctly.
- [x] Switch tabs to Users / Invites / Backup → all existing functionality (edit, delete, reset link, revoke invite, export users, import users, export calendar, import calendar) still works; dialogs open/close from any tab.
- [x] Force a `logEvent` to throw (temporarily corrupt the prepared statement) → parent request still succeeds; error visible in stderr.

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)